### PR TITLE
feat: allow nullable only properties

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -225,7 +225,7 @@ export class Parser {
     })
 
     if (!typeString) {
-      return null
+      return this.isNullable(schema) ? 'null' : null
     }
 
     if (this.isNullable(schema)) {


### PR DESCRIPTION
## Use Case
```yaml
components:
  schemas:
    User:
      type: object
      properties:
        gender:
          oneOf:
            - $ref: '#/components/schemas/Gender'
            - nullable: true
      required:
        - gender
```
↓
The parsed `typeString` for `User` scheme will be `{ gender: Gender | null }`
